### PR TITLE
feat/metadata_transformers

### DIFF
--- a/neon_transformers/__init__.py
+++ b/neon_transformers/__init__.py
@@ -29,3 +29,5 @@ from neon_transformers.audio_transformers import AudioTransformer, AudioTransfor
     find_audio_transformer_plugins, load_audio_transformer_plugin
 from neon_transformers.text_transformers import UtteranceTransformersService, UtteranceTransformer, \
     find_utterance_transformer_plugins, load_utterance_transformer_plugin
+from neon_transformers.metadata_transformers import MetadataTransformersService, MetadataTransformer, \
+    load_metadata_transformer_plugin, find_metadata_transformer_plugins

--- a/neon_transformers/metadata_transformers.py
+++ b/neon_transformers/metadata_transformers.py
@@ -1,0 +1,118 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Optional
+from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_plugins, load_metadata_transformer_plugin
+from ovos_utils.configuration import read_mycroft_config
+from ovos_utils.json_helper import merge_dict
+from ovos_utils.log import LOG
+from ovos_utils.messagebus import get_mycroft_bus
+from neon_transformers.tasks import MetadataTask
+
+
+class MetadataTransformer:
+    task = MetadataTask.OTHER
+
+    def __init__(self, name, priority=50, config=None):
+        self.name = name
+        self.bus = None
+        self.priority = priority
+        if not config:
+            config_core = read_mycroft_config()
+            config = config_core.get("metadata_transformers", {}).get(self.name)
+        self.config = config or {}
+
+    def bind(self, bus=None):
+        """ attach messagebus """
+        self.bus = bus or get_mycroft_bus()
+
+    def initialize(self):
+        """ perform any initialization actions """
+        pass
+
+    def transform(self, context: dict = None) -> (list, dict):
+        """
+        Optionally transform passed context
+        eg. inject default values or convert metadata format
+        :param context: existing Message context from all previous transformers
+        :returns: dict of possibly modified or additional context
+        """
+        context = context or {}
+        return context
+
+    def default_shutdown(self):
+        """ perform any shutdown actions """
+        pass
+
+
+class MetadataTransformersService:
+
+    def __init__(self, bus, config=None):
+        self.config_core = config or {}
+        self.loaded_modules = {}
+        self.has_loaded = False
+        self.bus = bus
+        self.config = self.config_core.get("metadata_transformers") or {}
+        self.load_plugins()
+
+    def load_plugins(self):
+        for plug_name, plug in find_metadata_transformer_plugins().items():
+            if plug_name in self.config:
+                # if disabled skip it
+                if not self.config[plug_name].get("active", True):
+                    continue
+                try:
+                    self.loaded_modules[plug_name] = plug()
+                    LOG.info(f"loaded metadata transformer plugin: {plug_name}")
+                except Exception as e:
+                    LOG.error(e)
+                    LOG.exception(f"Failed to load metadata transformer plugin: {plug_name}")
+
+    @property
+    def modules(self):
+        return sorted(self.loaded_modules.values(),
+                      key=lambda k: k.priority, reverse=True)
+
+    def shutdown(self):
+        for module in self.modules:
+            try:
+                module.shutdown()
+            except:
+                pass
+
+    def transform(self, context: Optional[dict] = None):
+        context = context or {}
+
+        for module in self.modules:
+            try:
+                data = module.transform(context)
+                LOG.debug(f"{module.name}: {data}")
+                context = merge_dict(context, data)
+            except Exception as e:
+                LOG.warning(f"{module.name} transform exception: {e}")
+        return context

--- a/neon_transformers/tasks.py
+++ b/neon_transformers/tasks.py
@@ -58,3 +58,14 @@ class AudioTask(enum.IntEnum):
     OTHER = enum.auto()
     REMOVE_NOISE = enum.auto()
     TRIM_SILENCE = enum.auto()
+
+
+class MetadataTask(enum.IntEnum):
+    """ A task is a user facing category
+    It is used in configuration files to assign preference to a plugin
+    when more than one solve the same problem
+    TRANSFORM, ADD_CONTEXT and OTHER are used as default values
+    """
+    TRANSFORM = enum.auto()
+    ADD_CONTEXT = enum.auto()
+    OTHER = enum.auto()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
-ovos-plugin-manager~=0.0.3
+ovos-plugin-manager~=0.0, >=0.0.18a6
 SpeechRecognition~=3.8


### PR DESCRIPTION
add a basic metadata task, intended for transformers that parse all existing context right before intent stage

this can be used to unify metadata into a common format, to interact with databases for user id and preferences etc

eg, a transformer version of https://github.com/NeonGeckoCom/NeonCore/pull/24 and https://github.com/NeonGeckoCom/NeonCore/pull/25 would be possible

the intended usage is AFTER the other transformers, a metadata transformer could for example require a audio transformer for speaker identification

needs https://github.com/OpenVoiceOS/OVOS-plugin-manager/pull/64