### PR TITLE
Fix type annotation to be Python 3.8 Compatible

### DIFF
--- a/neon_transformers/text_transformers.py
+++ b/neon_transformers/text_transformers.py
@@ -26,7 +26,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins, load_utterance_transformer_plugin
 from ovos_config.config import Configuration
 from ovos_utils.json_helper import merge_dict
@@ -56,7 +56,7 @@ class UtteranceTransformer:
         pass
 
     def transform(self, utterances: List[str],
-                  context: dict = None) -> tuple[list, dict]:
+                  context: dict = None) -> Tuple[list, dict]:
         """
         Optionally transform passed utterances and/or return additional context
         :param utterances: List of str utterances to parse


### PR DESCRIPTION
# Description
Fixes return type annotation

# Issues
Introduced in #29 as an accepted VSCode resolution

# Other Notes
Issue noted in https://github.com/NeonGeckoCom/NeonCore/actions/runs/13825019179/job/38678258637?pr=732